### PR TITLE
#7 AnyUri Datatype do not permit a empty AttributeValue

### DIFF
--- a/src/main/java/org/herasaf/xacml/core/dataTypeAttribute/impl/AnyURIDataTypeAttribute.java
+++ b/src/main/java/org/herasaf/xacml/core/dataTypeAttribute/impl/AnyURIDataTypeAttribute.java
@@ -18,6 +18,8 @@ package org.herasaf.xacml.core.dataTypeAttribute.impl;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.List;
 
 import org.herasaf.xacml.core.SyntaxException;
 
@@ -34,9 +36,20 @@ public class AnyURIDataTypeAttribute extends AbstractDataTypeAttribute<URI> {
     public String getDatatypeURI() {
         return ID;
     }
+    
+    /** {@inheritDoc} */
+    @Override
+    public URI convertTo(List<?> jaxbRepresentation) throws SyntaxException {
+        if (jaxbRepresentation.isEmpty()) {
+            return convertTo("");
+        }
+        URI convertedValue = super.convertTo(jaxbRepresentation);
+        return convertedValue;
+    }
 
     /** {@inheritDoc} */
     @Override
+    
     public URI convertTo(String jaxbRepresentation) throws SyntaxException {
         try {
             URI uri = new URI(jaxbRepresentation);

--- a/src/test/java/org/herasaf/xacml/core/dataTypeAttribute/impl/test/TestAnyURIDataTypeAttribute.java
+++ b/src/test/java/org/herasaf/xacml/core/dataTypeAttribute/impl/test/TestAnyURIDataTypeAttribute.java
@@ -21,6 +21,7 @@ import static org.testng.Assert.assertEquals;
 
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.herasaf.xacml.core.SyntaxException;
@@ -69,6 +70,13 @@ public class TestAnyURIDataTypeAttribute {
 		data.add("hallo/du/.ch");
 		assertEquals(dataType.convertTo(data), new URI("hallo/du/.ch"));
 	}
+	
+	@Test
+	public void testEmpty() throws Exception{
+		List<String> data = Collections.emptyList();
+		assertEquals(dataType.convertTo(data), new URI(""));
+	}
+	
 	
 	/**
 	 * Tests if the datatype does not accept illegal arguments.


### PR DESCRIPTION
Prevent syntax error for empty AttributeValue on AnyUri (fixes #7 )